### PR TITLE
Fixed typo that was breaking Blender 2.79 and below

### DIFF
--- a/fspy_blender/addon.py
+++ b/fspy_blender/addon.py
@@ -139,7 +139,7 @@ class ImportfSpyProject(Operator, ImportHelper):
             space_data = area.spaces.active
 
             # Show background images
-            if hasattr(space_data, 'show_background_image'):
+            if hasattr(space_data, 'show_background_images'):
                 space_data.show_background_images = True
             else:
                 #2.8


### PR DESCRIPTION
This fixes this addon for Blender 2.79 and below. The call to hasattr had the incorrect attribute name, so it was always taking the 2.8 branch.