### PR TITLE
update: support for blender 4.2, 5 or higher

### DIFF
--- a/build.py
+++ b/build.py
@@ -11,7 +11,7 @@ for line in init_file.readlines():
         version_string = line.split("(")[1]
         version_string = version_string.split(")")[0]
         version_parts = version_string.split(",")
-        version_parts = map(str.strip, version_parts)
+        version_parts = list(map(str.strip, version_parts))
         break
 init_file.close()
 
@@ -32,7 +32,10 @@ zipf = zipfile.ZipFile(
 )
 
 for py_file in glob.glob(os.path.join(src_dir_name, '*.py')):
-    zipf.write(py_file)
+    zipf.write(py_file, arcname=os.path.basename(py_file))
+
+manifest_path = os.path.join(src_dir_name, 'blender_manifest.toml')
+zipf.write(manifest_path, arcname='blender_manifest.toml')
 
 zipf.close()
 

--- a/fspy_blender/blender_manifest.toml
+++ b/fspy_blender/blender_manifest.toml
@@ -1,0 +1,15 @@
+schema_version = "1.0.0"
+
+id = "fspy_blender"
+version = "1.0.3"
+name = "Import fSpy project"
+tagline = "Imports the background image and camera parameters from an fSpy project"
+maintainer = "Per Gantelius"
+type = "add-on"
+
+tags = ["Import-Export"]
+
+blender_version_min = "4.2.0"
+
+license = ["SPDX:GPL-3.0-or-later"]
+website = "https://github.com/stuffmatic/fSpy-Blender"


### PR DESCRIPTION
Blender 4.2 introduced the "Extensions" system, and Blender 5.0 no longer recognizes the old bl_info-only format. The empty () in "Modules Installed ()" is Blender telling you it found no valid extension to install.

Changes made:

fspy_blender/blender_manifest.toml (new file) — This is what Blender 4.2+/5.x requires to recognize an addon as an Extension. It declares the id, version, name, type, minimum Blender version, and license.

The zip now stores files flat at the root (e.g. __init__.py, not fspy_blender/__init__.py) and includes blender_manifest.toml. The Extensions system requires this flat layout.

Fixed a pre-existing Python 3 bug where map() was used with len(), which caused the build script to crash.

To install: Run python3 build.py, then install dist/fSpy-Blender-1.0.3.zip in Blender 5